### PR TITLE
added hauberk repo under Browser Based - Other

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ A selection of major game studios, publishers, etc. using GitHub:
 * [Squirts](https://github.com/KrofDrakula/squirts) - A well-known indie game implemented in JavaScript. [Play now!](http://is.gd/squirts)
 * [The Killer](https://github.com/JordanMagnuson/The-Killer) - a flash/as3-based "nongame". [Play it now!](http://www.gametrekking.com/the-games/cambodia/the-killer/play-now)
 * [binb](https://github.com/lpinca/binb) - A competitive, multiplayer, realtime, guess the song game. [Play now!](http://binb.nodejitsu.com)
+* [Hauberk](https://github.com/munificent/hauberk) - Hauberk is a roguelike, an ASCII-art based procedurally-generated dungeon crawl game. It's written in Dart and runs in your browser.
 
 -------
 


### PR DESCRIPTION
Added a browser based game repo. I was not sure what category to put it in, so I just stuck it under 'Browser Based - Other'