### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,6 @@ A selection of major game studios, publishers, etc. using GitHub:
 
 * [Command & Conquer](https://github.com/adityaravishankar/command-and-conquer) - Clone of the popular RTS. [Play it now!](http://www.adityaravishankar.com/projects/games/command-and-conquer/)
 * [Freeciv-web](https://github.com/freeciv/freeciv-web) - An turn-based strategy game implemented in HTML5. [Play it now!](http://play.freeciv.org/)
-* [StarCraft](https://github.com/gloomyson/StarCraft) - Classic RTS StarCraft BroodWar using HTML5. [Play it now!](http://gloomyson.github.io/StarCraft/)
 * [Tower Defense](https://github.com/Casmo/tower-defense) - 3D Tower Defense build with Three.js in HTML5. [Play it now!](http://www.fellicht.nl/games/tower-defense/)
 
 ## Racing


### PR DESCRIPTION
Removed StarCraft from Strategy category.

StarCraft repo disabled.

> Repository unavailable due to DMCA takedown.

> This repository is currently disabled due to a DMCA takedown notice. We have disabled public access to the repository. The notice has been publicly posted.

> If you are the repository owner, and you believe that your repository was disabled as a result of mistake or misidentification, you have the right to file a counter notice and have the repository reinstated. Our help articles provide more details on our DMCA takedown policy and how to file a counter notice. If you have any questions about the process or the risks in filing a counter notice, we suggest that you consult with a lawyer.