### PR TITLE
Fixed Broken Trigger Rally link

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ A selection of major game studios, publishers, etc. using GitHub:
 ## Racing
 
 * [HexGL](https://github.com/BKcore/HexGL) - Futuristic HTML5 racing game by Thibaut Despoulain using HTML5, Javascript and WebGL. [Play it now!](http://hexgl.bkcore.com/)
-* [Trigger Rally Online Edition](https://github.com/CodeArtemis/TriggerRally) - Fast arcade rally racing. [Play it now!](https://triggerrally.com/)
+* [Trigger Rally Online Edition](https://github.com/CodeArtemis/TriggerRally) - Fast arcade rally racing. [Play it now!](http://codeartemis.github.io/TriggerRally/server/public/)
 
 ## Sandbox
 


### PR DESCRIPTION
The link to the Trigger Rally game was broken, and led to a non-existent domain.

The developer seems to be using Github pages to host the game now.

Updated the link to the new one.
