### PR TITLE
Changed LeaderBoard (Python) link

### DIFF
--- a/README.md
+++ b/README.md
@@ -557,7 +557,7 @@ A selection of major game studios, publishers, etc. using GitHub:
 * [JavaScript Breakouts](https://github.com/city41/breakouts) - Collection of JavaScript engine implementations of [*Breakout*](http://en.wikipedia.org/wiki/Breakout_%28video_game%29).
 * [Leaderboard(Java)](https://github.com/agoragames/java-leaderboard) - Leaderboards backed by Redis(in Java).
 * [Leaderboard(PHP)](https://github.com/agoragames/php-leaderboard) - Leaderboards backed by Redis(in PHP).
-* [Leaderboard(Python)](https://github.com/agoragames/python-leaderboard) - Leaderboards backed by Redis(in Python).
+* [Leaderboard(Python)](https://github.com/agoragames/leaderboard-python) - Leaderboards backed by Redis(in Python).
 * [Leaderboard(Ruby)](https://github.com/agoragames/leaderboard) - Leaderboards backed by Redis(in Ruby).
 * [Leaderboard(Scala)](https://github.com/agoragames/scala-leaderboard) - Leaderboards backed by Redis (in Scala).
 * [libfreenect](https://github.com/OpenKinect/libfreenect) - Drivers and libraries for the Xbox Kinect device on WIndows, Linux, and OS X.


### PR DESCRIPTION
**Maintenance task:**
The python leader board link will not longer work soon as the repository is being deleted. The link was updated to the new repository. 