### PR TITLE
Add Number-Guess

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,6 +475,7 @@ A selection of major game studios, publishers, etc. using GitHub:
 * [Prince of Persia](https://github.com/jmechner/Prince-of-Persia-Apple-II) - Source code for the original Prince of Persia game that was written on the Apple II, in 6502 assembly language, between 1985-89.
 * [UFO RUN](https://github.com/Nextpeer/Nextpeer-UFORUN) - Real time multiplayer with Nextpeer.
 * [System Shock](https://github.com/NightDiveStudios/shockmac/) - Source code for original System Shock game (PowerMac version), more readable fork available [here](https://github.com/ToxicFrog/shockmac).
+* [Number Guess](https://github.com/TheHungrySomeone/Number-Guess) - A simple Guess the Number game written in bash
 
 -------
 


### PR DESCRIPTION
I want to add my guess the number game to this list.  I put it in the "Just The Source" section, but I'm not sure that's where it should go.  Please tell me if I should put it somewhere else.  Here is the [repository](https://github.com/TheHungrySomeone/Number-Guess) for my game.