### PR TITLE
Correct release year for Open Meridian

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ A selection of major game studios, publishers, etc. using GitHub:
 
 ## MMORPG
 
-* [Open Meridian](https://github.com/OpenMeridian/Meridian59) - The first 3D MMORPG, released in 1996 and open sourced in 2012. Forked in 2013, Actively developed. [Play it now!](http://openmeridian.org)
+* [Open Meridian](https://github.com/OpenMeridian/Meridian59) - The first 3D MMORPG, released in 1995 and open sourced in 2012. Forked in 2013, Actively developed. [Play it now!](http://openmeridian.org)
 * [Meridian 59](https://github.com/Meridian59/Meridian59) - The first 3D MMORPG, released in 1996 and open sourced in 2012. The original codebase for Meridian 59, less frequently updated. [Play it now!](http://www.meridian59.com)
 * [Stendhal](https://github.com/arianne/stendhal) - a fun friendly and free 2D multiplayer online adventure game with an old school feel. [Play it now!](https://stendhalgame.org)
 


### PR DESCRIPTION
"Meridian 59 is a long-running medieval fantasy combat and adventure MMO, and was the first commercial 3D MUD upon its release in 1995."
- https://openmeridian.org